### PR TITLE
Feat/add docs menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 public/
+.hugo_build.lock

--- a/config.toml
+++ b/config.toml
@@ -9,16 +9,29 @@ theme = "gokarna"
         url = "/"
         name = "Home"
         weight = 1
+        [menu.main.params]
+            target= "_self"
+    [[menu.main]]
+        identifier = "documentation"
+        url = "https://docs.c13n.io"
+        name = "Documentation"
+        weight = 2
+        [menu.main.params]
+            target= "_blank"
     [[menu.main]]
         identifier = "about"
         url = "/about/"
         name = "About"
-        weight = 2
+        weight = 3
+        [menu.main.params]
+            target= "_self"
     [[menu.main]]
         identifier = "contact"
         url = "/contact/"
         name = "Contact"
         weight = 4
+        [menu.main.params]
+            target= "_self"
 [params]
     avatarURL = "https://c13n.io/c13n-avatar.png"
     avatarSize = "size-xl"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,56 @@
+<header class="header">
+    <nav class="header-nav">
+
+        {{ if isset .Site.Params "avatarurl" }}
+        <div class="avatar">
+            <a href="{{ .Site.BaseURL }}">
+                <img src="{{ .Site.Params.AvatarURL }}" alt="avatar" />
+            </a>
+        </div>
+        {{ end }}
+
+        <div class="nav-title">
+            <a class="nav-brand" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+        </div>
+
+        <div class="nav-links">
+            {{ range .Site.Menus.main }}
+            <div class="nav-link">
+                <a href="{{ .URL }}" target="{{ with .Params.target }}{{ . }}{{ end }}">
+                    {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
+                </a>
+            </div>
+            {{ end }}
+
+            <span class="nav-icons-divider"></span>
+            <div class="nav-link dark-theme-toggle">
+                <a>
+                    <span id="theme-toggle-icon" data-feather="moon"></span>
+                </a>
+            </div>
+
+            <div class="nav-link" id="hamburger-menu-toggle">
+                <a>
+                    <span data-feather="menu"></span>
+                </a>
+            </div>
+
+            <!-- For mobile -->
+            <ul class="nav-hamburger-list visibility-hidden">
+                {{ range .Site.Menus.main }}
+                <li class="nav-item">
+                    <a href="{{ .URL }}">
+                        {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
+                    </a>
+                </li>
+                {{ end }}
+                <li class="nav-item dark-theme-toggle">
+                    <a>
+                        <span id="theme-toggle-icon" data-feather="moon"></span>
+                    </a>
+                </li>
+            </ul>
+
+        </div>
+    </nav>
+</header>


### PR DESCRIPTION
This MR adds the Documentation menu entry to the header Main menu. In order to make it open to a new page, considering our base theme does not support additional parameters for menu entries, a new, override partial should be created for header. THis is located at `layouts/partials/header.html`.

New header:
![image](https://user-images.githubusercontent.com/1295367/145638339-40562e98-9a52-4b8a-a916-417306960562.png)
